### PR TITLE
Reproduce ray issue 53848 locally

### DIFF
--- a/ray-issue-53848-repro/README.md
+++ b/ray-issue-53848-repro/README.md
@@ -1,0 +1,99 @@
+# Ray Issue #53848 Reproduction
+
+This repository contains a minimal reproduction for [Ray issue #53848](https://github.com/ray-project/ray/issues/53848).
+
+## Issue Summary
+
+In Ray 2.48.0, when using the `uv` field in `runtime_env`, Ray fails to set up the runtime environment with the error:
+```
+No module named pip
+```
+
+This happens because Ray tries to install the `uv` package using pip in a virtualenv that doesn't have pip installed.
+
+## Root Cause
+
+1. When you specify `runtime_env={"uv": ["package-list"]}`, Ray uses its UV runtime environment feature
+2. Ray creates a virtualenv for the runtime environment
+3. Ray then tries to install `uv` into that virtualenv using: `python -m pip install uv`
+4. However, the virtualenv doesn't have pip installed, causing the failure
+
+## Reproduction Steps
+
+### Prerequisites
+
+1. Install uv:
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. Create a virtual environment and install Ray 2.48.0:
+   ```bash
+   uv venv .venv
+   source .venv/bin/activate
+   uv pip install "ray==2.48.0"
+   ```
+
+### Run the Reproduction
+
+```bash
+python minimal_repro.py
+```
+
+This will show:
+```
+======================================================================
+Ray Issue #53848 - Minimal Reproduction
+Ray version: 2.48.0
+======================================================================
+
+Trying to use UV runtime environment...
+This will fail with 'No module named pip' error
+✓ Ray initialized successfully
+Running remote function to trigger runtime env setup...
+
+✗ Failed as expected!
+Error: RuntimeEnvSetupError
+
+--- Key Issue Found ---
+Ray creates a virtualenv and tries to install UV using:
+  python -m pip install uv
+But the virtualenv doesn't have pip installed!
+```
+
+## Workaround
+
+The workaround mentioned in the Slack thread is to set:
+```bash
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0
+```
+
+However, this doesn't actually disable the UV runtime environment when you use the `uv` field. Instead, you should use the `pip` field in your runtime_env:
+
+```python
+# Don't use this (triggers UV runtime env):
+runtime_env = {"uv": ["requests==2.31.0"]}
+
+# Use this instead:
+runtime_env = {"pip": ["requests==2.31.0"]}
+```
+
+## Files in this Repository
+
+- `minimal_repro.py` - Minimal script that reproduces the issue
+- `test_runtime_env_uv.py` - Test using UV runtime environment
+- `test_runtime_env_pip.py` - Test using traditional pip runtime environment
+- `test_runtime_env_requirements.py` - Test using requirements.txt
+- `test_runtime_env_working_dir.py` - Test with working_dir
+- `reproduce_issue_53848.py` - Comprehensive reproduction script
+
+## Environment Details
+
+- Ray version: 2.48.0
+- Python version: 3.11+
+- UV version: 0.8.13
+
+## Related Links
+
+- [Ray Issue #53848](https://github.com/ray-project/ray/issues/53848) (if accessible)
+- [UV Documentation](https://docs.astral.sh/uv/)

--- a/ray-issue-53848-repro/issue_summary.md
+++ b/ray-issue-53848-repro/issue_summary.md
@@ -1,0 +1,60 @@
+# Ray Issue #53848 - Summary of Findings
+
+## Key Discovery
+
+The issue occurs when using the `uv` field in Ray's `runtime_env` configuration. This triggers Ray's UV runtime environment feature, which fails in Ray 2.48.0.
+
+## The Problem
+
+```python
+runtime_env = {"uv": ["requests==2.31.0"]}  # This triggers the issue
+ray.init(runtime_env=runtime_env)
+```
+
+When you use the `uv` field, Ray:
+1. Creates a virtualenv for the runtime environment
+2. Tries to install `uv` package into that virtualenv using: `python -m pip install uv`
+3. **FAILS** because the virtualenv doesn't have pip installed
+
+Error message:
+```
+ray._private.runtime_env.utils.SubprocessCalledProcessError: Run cmd[12] failed with the following details.
+Command '['/tmp/ray/session.../virtualenv/bin/python', '-m', 'pip', 'install', '--disable-pip-version-check', '--no-cache-dir', 'uv']' returned non-zero exit status 1.
+Last 50 lines of stdout:
+    /tmp/ray/session.../virtualenv/bin/python: No module named pip
+```
+
+## About RAY_ENABLE_UV_RUN_RUNTIME_ENV
+
+Initially, it seemed like `RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` would fix the issue, but our testing reveals:
+
+- `RAY_ENABLE_UV_RUN_RUNTIME_ENV` is **enabled by default** in Ray 2.48.0
+- This flag is about propagating `uv run` environments from driver to workers
+- It does **NOT** control whether the `uv` field in runtime_env works
+- Setting it to 0 doesn't prevent the error when using `runtime_env={"uv": [...]}`
+
+## Solution
+
+Don't use the `uv` field in runtime_env. Use `pip` instead:
+
+```python
+# ❌ Don't do this - triggers the bug:
+runtime_env = {"uv": ["requests==2.31.0"]}
+
+# ✅ Do this instead:
+runtime_env = {"pip": ["requests==2.31.0"]}
+```
+
+## Root Cause Analysis
+
+The issue is in Ray's UV runtime environment implementation (`ray._private.runtime_env.uv`):
+- It assumes pip is available in the created virtualenv
+- Modern virtualenv installations may not include pip by default
+- Ray needs to either:
+  1. Ensure pip is installed when creating the virtualenv
+  2. Use uv directly without going through pip
+  3. Create virtualenvs with pip included (`virtualenv --with-pip`)
+
+## Reproduction
+
+See `minimal_repro.py` for a clean reproduction that demonstrates the issue.

--- a/ray-issue-53848-repro/minimal_repro.py
+++ b/ray-issue-53848-repro/minimal_repro.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Minimal reproduction for Ray issue #53848
+Shows that UV runtime environment fails in Ray 2.48.0
+"""
+
+import ray
+import os
+
+print("=" * 70)
+print("Ray Issue #53848 - Minimal Reproduction")
+print(f"Ray version: {ray.__version__}")
+print("=" * 70)
+
+# The issue manifests when using the 'uv' field in runtime_env
+# Ray tries to install uv using pip in a virtualenv that doesn't have pip
+
+runtime_env = {
+    "uv": ["requests==2.31.0"]  # Using 'uv' field triggers the UV runtime env
+}
+
+print("\nTrying to use UV runtime environment...")
+print("This will fail with 'No module named pip' error")
+
+try:
+    ray.init(runtime_env=runtime_env)
+    print("✓ Ray initialized successfully")
+    
+    # We need to actually run a remote function to trigger the runtime env setup
+    @ray.remote
+    def test_import():
+        import requests
+        return f"requests version: {requests.__version__}"
+    
+    print("Running remote function to trigger runtime env setup...")
+    result = ray.get(test_import.remote())
+    print(f"✓ Success: {result}")
+    
+except Exception as e:
+    print(f"\n✗ Failed as expected!")
+    print(f"Error: {type(e).__name__}")
+    error_msg = str(e)
+    if "No module named pip" in error_msg:
+        print("\n--- Key Issue Found ---")
+        print("Ray creates a virtualenv and tries to install UV using:")
+        print("  python -m pip install uv")
+        print("But the virtualenv doesn't have pip installed!")
+        print("\nThis is why users need to set RAY_ENABLE_UV_RUN_RUNTIME_ENV=0")
+        
+        # Show the failing command
+        import re
+        cmd_match = re.search(r"Command '(\[.*?\])'", error_msg)
+        if cmd_match:
+            print(f"\nFailing command: {cmd_match.group(1)}")
+finally:
+    ray.shutdown()
+
+print("\n" + "=" * 70)
+print("WORKAROUND: Don't use 'uv' field in runtime_env, use 'pip' instead")

--- a/ray-issue-53848-repro/pyproject.toml
+++ b/ray-issue-53848-repro/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "ray-issue-53848-repro"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []

--- a/ray-issue-53848-repro/reproduce_issue_53848.py
+++ b/ray-issue-53848-repro/reproduce_issue_53848.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Reproduction script for Ray issue #53848
+This demonstrates the issue with RAY_ENABLE_UV_RUN_RUNTIME_ENV in Ray 2.48.0
+
+The issue occurs when Ray tries to use UV for runtime environments but fails
+because it attempts to install UV using pip in a virtualenv that doesn't have pip.
+"""
+
+import ray
+import os
+import sys
+
+def test_uv_runtime_env():
+    """Test using UV-based runtime environment"""
+    print("=" * 60)
+    print("Testing UV runtime environment")
+    print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+    print(f"Ray version: {ray.__version__}")
+    print("=" * 60)
+    
+    # Use UV field for runtime environment
+    runtime_env = {
+        "uv": ["requests==2.31.0", "numpy==1.26.0"]
+    }
+    
+    try:
+        ray.init(runtime_env=runtime_env)
+        
+        @ray.remote
+        def check_packages():
+            import requests
+            import numpy as np
+            return f"requests: {requests.__version__}, numpy: {np.__version__}"
+        
+        result = ray.get(check_packages.remote())
+        print(f"✓ Success: {result}")
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed with {type(e).__name__}: {e}")
+        # Extract the key error details
+        if "No module named pip" in str(e):
+            print("\nKey issue: virtualenv created without pip module")
+        return False
+    finally:
+        ray.shutdown()
+
+def test_pip_runtime_env():
+    """Test using traditional pip-based runtime environment"""
+    print("\n" + "=" * 60)
+    print("Testing pip runtime environment (traditional)")
+    print("=" * 60)
+    
+    runtime_env = {
+        "pip": ["requests==2.31.0", "numpy==1.26.0"]
+    }
+    
+    try:
+        ray.init(runtime_env=runtime_env)
+        
+        @ray.remote
+        def check_packages():
+            import requests
+            import numpy as np
+            return f"requests: {requests.__version__}, numpy: {np.__version__}"
+        
+        result = ray.get(check_packages.remote())
+        print(f"✓ Success: {result}")
+        return True
+        
+    except Exception as e:
+        print(f"✗ Failed with {type(e).__name__}: {e}")
+        return False
+    finally:
+        ray.shutdown()
+
+def main():
+    print("Ray Issue #53848 Reproduction")
+    print("This reproduces the UV runtime environment issue in Ray 2.48.0")
+    print()
+    
+    # Test 1: With UV enabled (should fail)
+    print("\n--- Test 1: UV enabled (expected to fail) ---")
+    os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "1"
+    uv_success = test_uv_runtime_env()
+    
+    # Test 2: With UV disabled (should work)
+    print("\n--- Test 2: UV disabled (expected to work) ---")
+    os.environ["RAY_ENABLE_UV_RUN_RUNTIME_ENV"] = "0"
+    uv_disabled_success = test_uv_runtime_env()
+    
+    # Test 3: Traditional pip (should fail due to missing pip in virtualenv)
+    print("\n--- Test 3: Traditional pip runtime_env ---")
+    pip_success = test_pip_runtime_env()
+    
+    # Summary
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"UV with RAY_ENABLE_UV_RUN_RUNTIME_ENV=1: {'✓ Passed' if uv_success else '✗ Failed'}")
+    print(f"UV with RAY_ENABLE_UV_RUN_RUNTIME_ENV=0: {'✓ Passed' if uv_disabled_success else '✗ Failed'}")
+    print(f"Traditional pip runtime_env: {'✓ Passed' if pip_success else '✗ Failed'}")
+    
+    print("\nISSUE: Ray 2.48.0 fails to properly set up UV runtime environments")
+    print("because it tries to install UV using pip in a virtualenv without pip.")
+    print("\nWORKAROUND: Set RAY_ENABLE_UV_RUN_RUNTIME_ENV=0")
+
+if __name__ == "__main__":
+    main()

--- a/ray-issue-53848-repro/requirements.txt
+++ b/ray-issue-53848-repro/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.31.0
+numpy==1.26.0
+pandas==2.1.0

--- a/ray-issue-53848-repro/test_basic_ray.py
+++ b/ray-issue-53848-repro/test_basic_ray.py
@@ -1,0 +1,19 @@
+import ray
+import os
+
+# Print environment variable status
+print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+
+# Initialize Ray
+ray.init()
+
+@ray.remote
+def hello_world():
+    return "Hello from Ray!"
+
+# Test basic Ray functionality
+result = ray.get(hello_world.remote())
+print(f"Basic test result: {result}")
+
+ray.shutdown()
+print("Basic Ray test completed successfully")

--- a/ray-issue-53848-repro/test_runtime_env_pip.py
+++ b/ray-issue-53848-repro/test_runtime_env_pip.py
@@ -1,0 +1,26 @@
+import ray
+import os
+
+print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+
+# Initialize Ray with a runtime_env that includes pip packages
+runtime_env = {
+    "pip": ["requests==2.31.0", "numpy==1.26.0"]
+}
+
+ray.init(runtime_env=runtime_env)
+
+@ray.remote
+def check_packages():
+    import requests
+    import numpy as np
+    return f"requests version: {requests.__version__}, numpy version: {np.__version__}"
+
+try:
+    result = ray.get(check_packages.remote())
+    print(f"Runtime env test result: {result}")
+    print("Runtime env with pip test completed successfully")
+except Exception as e:
+    print(f"Error with runtime env: {type(e).__name__}: {e}")
+finally:
+    ray.shutdown()

--- a/ray-issue-53848-repro/test_runtime_env_requirements.py
+++ b/ray-issue-53848-repro/test_runtime_env_requirements.py
@@ -1,0 +1,27 @@
+import ray
+import os
+
+print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+
+# Initialize Ray with a runtime_env that uses requirements.txt
+runtime_env = {
+    "pip": "./requirements.txt"
+}
+
+ray.init(runtime_env=runtime_env)
+
+@ray.remote
+def check_packages():
+    import requests
+    import numpy as np
+    import pandas as pd
+    return f"requests: {requests.__version__}, numpy: {np.__version__}, pandas: {pd.__version__}"
+
+try:
+    result = ray.get(check_packages.remote())
+    print(f"Runtime env test result: {result}")
+    print("Runtime env with requirements.txt test completed successfully")
+except Exception as e:
+    print(f"Error with runtime env: {type(e).__name__}: {e}")
+finally:
+    ray.shutdown()

--- a/ray-issue-53848-repro/test_runtime_env_uv.py
+++ b/ray-issue-53848-repro/test_runtime_env_uv.py
@@ -1,0 +1,28 @@
+import ray
+import os
+
+print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+
+# Initialize Ray with a runtime_env that uses uv packages
+runtime_env = {
+    "uv": ["requests==2.31.0", "numpy==1.26.0"]
+}
+
+ray.init(runtime_env=runtime_env)
+
+@ray.remote
+def check_packages():
+    import requests
+    import numpy as np
+    return f"requests version: {requests.__version__}, numpy version: {np.__version__}"
+
+try:
+    result = ray.get(check_packages.remote())
+    print(f"Runtime env test result: {result}")
+    print("Runtime env with uv test completed successfully")
+except Exception as e:
+    print(f"Error with runtime env: {type(e).__name__}: {e}")
+    import traceback
+    traceback.print_exc()
+finally:
+    ray.shutdown()

--- a/ray-issue-53848-repro/test_runtime_env_working_dir.py
+++ b/ray-issue-53848-repro/test_runtime_env_working_dir.py
@@ -1,0 +1,44 @@
+import ray
+import os
+import tempfile
+import shutil
+
+print(f"RAY_ENABLE_UV_RUN_RUNTIME_ENV = {os.environ.get('RAY_ENABLE_UV_RUN_RUNTIME_ENV', 'not set')}")
+
+# Create a temporary working directory with some Python files
+with tempfile.TemporaryDirectory() as tmpdir:
+    # Create a simple module in the temporary directory
+    module_path = os.path.join(tmpdir, "mymodule.py")
+    with open(module_path, "w") as f:
+        f.write("""
+def get_message():
+    return "Hello from mymodule!"
+""")
+    
+    # Create a requirements.txt in the working dir
+    req_path = os.path.join(tmpdir, "requirements.txt")
+    with open(req_path, "w") as f:
+        f.write("requests==2.31.0\n")
+    
+    # Initialize Ray with a runtime_env that uses working_dir
+    runtime_env = {
+        "working_dir": tmpdir,
+        "pip": os.path.join(tmpdir, "requirements.txt")
+    }
+    
+    ray.init(runtime_env=runtime_env)
+    
+    @ray.remote
+    def test_working_dir():
+        import mymodule
+        import requests
+        return f"Module says: {mymodule.get_message()}, requests version: {requests.__version__}"
+    
+    try:
+        result = ray.get(test_working_dir.remote())
+        print(f"Working dir test result: {result}")
+        print("Runtime env with working_dir test completed successfully")
+    except Exception as e:
+        print(f"Error with runtime env: {type(e).__name__}: {e}")
+    finally:
+        ray.shutdown()


### PR DESCRIPTION
## Why are these changes needed?

This PR provides a minimal, isolated reproduction for a bug in Ray 2.48.0 where using the `uv` field in `runtime_env` fails with a "No module named pip" error. This occurs because Ray attempts to install `uv` using `pip` in a virtual environment that does not have `pip` installed, preventing the `uv` runtime environment from being set up correctly.

## Related issue number

Addresses the `uv` runtime environment setup failure reported in the context of #53848.

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :(

---
[Slack Thread](https://anysphere.slack.com/archives/C09AEJNDXC4/p1755287019811839?thread_ts=1755287019.811839&cid=C09AEJNDXC4)

<a href="https://cursor.com/background-agent?bcId=bc-40e7bdaa-00ba-4c1f-b673-1706d601ebae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40e7bdaa-00ba-4c1f-b673-1706d601ebae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

