### PR TITLE
Reproduce ray issue 53848 with uv

### DIFF
--- a/ray-uv-repro/README.md
+++ b/ray-uv-repro/README.md
@@ -1,0 +1,53 @@
+# Ray + uv runtime_env repro
+
+This is a minimal scaffold to exercise Ray's uv-based runtime_env path and compare to pip-based runtime_env.
+
+## Setup
+
+```bash
+cd /workspace/ray-uv-repro
+source .venv/bin/activate
+```
+
+## Run (Ray 2.48.0)
+
+```bash
+uv pip install "ray[default]==2.48.0"
+USE_UV=1 python repro.py    # uv backend
+USE_UV=0 python repro.py    # pip backend
+```
+
+## Run (Ray 2.47.0)
+
+```bash
+uv pip install -U "ray[default]==2.47.0"
+USE_UV=1 python repro.py
+USE_UV=0 python repro.py
+```
+
+If the regression in [ray-project/ray#53848](https://github.com/ray-project/ray/issues/53848) is present, the `USE_UV=1` run should hang or error while `USE_UV=0` succeeds.
+
+Current result in this environment:
+- 2.48.0: both uv and pip succeed
+- 2.47.0: both uv and pip succeed (no hang triggered with this minimal script)
+
+To explore further, try increasing dependency work:
+```bash
+# Heavier deps
+export USE_UV=1
+python - <<'PY'
+import ray, os
+pkgs = [
+    "numpy==1.26.4",
+    "pandas==2.2.2",
+    "pyarrow==15.0.2",
+    "requests==2.31.0",
+]
+runtime_env = {"uv": {"packages": pkgs}}
+ray.init(runtime_env=runtime_env)
+@ray.remote
+def f():
+    import pandas as pd; import pyarrow as pa; return (pd.__version__, pa.__version__)
+print(ray.get(f.remote()))
+PY
+```

--- a/ray-uv-repro/repro.py
+++ b/ray-uv-repro/repro.py
@@ -1,0 +1,52 @@
+import os
+import time
+import ray
+
+use_uv = os.environ.get("USE_UV", "0") == "1"
+print(f"USE_UV={use_uv}")
+print(f"ray.__version__={ray.__version__}")
+
+# Use a runtime_env that requires building an env with dependencies
+if use_uv:
+	runtime_env = {
+		"uv": {
+			"packages": [
+				"numpy==1.26.4",
+				"requests==2.31.0",
+			],
+			"uv_pip_install_options": ["--no-cache"],
+		}
+	}
+	msg = "Initializing Ray with runtime_env.uv..."
+else:
+	runtime_env = {
+		"pip": [
+			"numpy==1.26.4",
+			"requests==2.31.0",
+		],
+	}
+	msg = "Initializing Ray with runtime_env.pip..."
+
+print(msg, flush=True)
+ray.init(runtime_env=runtime_env, ignore_reinit_error=True)
+
+@ray.remote
+def ping():
+	import numpy as _np
+	return ("ok", str(_np.__version__))
+
+print("Submitting task...", flush=True)
+obj = ping.remote()
+
+start = time.time()
+try:
+	res = ray.get(obj, timeout=60)
+	print("Task result:", res)
+	print("SUCCESS")
+	exit(0)
+except ray.exceptions.GetTimeoutError:
+	print("HANG: ray.get timed out after 60s", flush=True)
+	exit(2)
+except Exception as e:
+	print("ERROR:", repr(e), flush=True)
+	raise


### PR DESCRIPTION
## Why are these changes needed?

This PR provides a minimal, isolated reproduction attempt for the hang reported in #53848, which occurs when using `runtime_env.uv` with `RAY_ENABLE_UV_RUN_RUNTIME_ENV=1`.

The current script does not reproduce the hang on Ray 2.47.0 or 2.48.0, but it serves as a baseline for further investigation.

## Related issue number

Related to #53848

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests (The provided script acts as a unit test for the runtime environment behavior)
   - [ ] Release tests
   - [ ] This PR is not tested :(

---
[Slack Thread](https://anysphere.slack.com/archives/C09AEJNDXC4/p1755287019811839?thread_ts=1755287019.811839&cid=C09AEJNDXC4)

<a href="https://cursor.com/background-agent?bcId=bc-0fb5c67e-a838-4376-b358-7f21560f3c85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fb5c67e-a838-4376-b358-7f21560f3c85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

